### PR TITLE
Removing "depends_on macos: :el_capitan"

### DIFF
--- a/Formula/class-dump.rb
+++ b/Formula/class-dump.rb
@@ -7,7 +7,6 @@ class ClassDump < Formula
   head "https://github.com/nygard/class-dump.git", branch: "master"
 
   depends_on xcode: :build
-  depends_on macos: :el_capitan
 
   def install
     inreplace "Source/CDLCBuildVersion.m", /PLATFORM_IOSMAC/, "PLATFORM_MACCATALYST"


### PR DESCRIPTION
In order to suppress warnings such as "Warning: Calling `depends_on macos: :el_capitan` is deprecated! There is no replacement."