### PR TITLE
Fix macOS dependency syntax for ipatool

### DIFF
--- a/Casks/ipatool.rb
+++ b/Casks/ipatool.rb
@@ -14,7 +14,7 @@ cask "ipatool" do
   desc "CLI tool for searching and downloading iOS app packages from the App Store"
   homepage "https://github.com/majd/ipatool"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   postflight do
     system "xattr", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/ipatool"


### PR DESCRIPTION
Updates `depends_on macos:` to the current Homebrew cask DSL form.\n\nHomebrew now warns that string comparison syntax such as `">= :catalina"` is deprecated and recommends `depends_on macos: :catalina`.