### PR TITLE
ipatool: fix deprecated depends_on macos string comparison

### DIFF
--- a/Casks/ipatool.rb
+++ b/Casks/ipatool.rb
@@ -14,7 +14,7 @@ cask "ipatool" do
   desc "CLI tool for searching and downloading iOS app packages from the App Store"
   homepage "https://github.com/majd/ipatool"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   postflight do
     system "xattr", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/ipatool"


### PR DESCRIPTION
## What

Change `depends_on macos: ">= :catalina"` to `depends_on macos: :catalina` in the `ipatool` cask.

## Why

Homebrew deprecated the string comparison format for `depends_on macos:`. The current line triggers this warning on **every** `brew` command run by anyone who has this tap installed:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
  .../majd/homebrew-repo/Casks/ipatool.rb:17
```

The symbol form `:catalina` already means "this version or newer", so the two are equivalent — this just silences the deprecation warning. Homebrew's own message recommends this exact replacement.

## Test

`brew style` / `brew audit` pass cleanly with no deprecation warning.