### PR TITLE
Removing stale "depends_on macos: :el_capitan"

### DIFF
--- a/Formula/class-dump.rb
+++ b/Formula/class-dump.rb
@@ -7,7 +7,6 @@ class ClassDump < Formula
   head "https://github.com/nygard/class-dump.git", branch: "master"
 
   depends_on xcode: :build
-  depends_on macos: :el_capitan
 
   def install
     inreplace "Source/CDLCBuildVersion.m", /PLATFORM_IOSMAC/, "PLATFORM_MACCATALYST"


### PR DESCRIPTION
Fixes:

Error: majd/repo/class-dump: Calling `depends_on macos: :el_capitan` is disabled! There is no replacement. Please report this issue to the majd/homebrew-repo tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/majd/homebrew-repo/Formula/class-dump.rb:10